### PR TITLE
Fixed #78 Invalid Icon 'component' propType

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,10 @@ Do you use React Native Elements in production? If so, consider supporting this 
 
 
 
-(https://opencollective.com/react-native-elements/sponsor/0/avatar)](https://opencollective.com/react-native-elements/sponsor/15/website)
+
+[![React Native Elements Backer](https://opencollective.com/react-native-elements/sponsor/11/avatar)](https://opencollective.com/react-native-elements/sponsor/11/website)
+
+
+
+
+[![React Native Elements Backer](https://opencollective.com/react-native-elements/sponsor/11/avatar)](https://opencollective.com/react-native-elements/sponsor/11/website)


### PR DESCRIPTION
I think React Native Components are mostly 'func' type. 'element' type returns true if it is constructed using React.createElement().