### PR TITLE
Fix: FormValidationMessage not importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ Do you use React Native Elements in production? If so, consider supporting this 
 
 
 
-[![React Native Elements Backer](https://opencollective.com/react-native-elements/sponsor/11/avatar)](https://opencollective.com/react-native-elements/sponsor/11/website)
+[![React Native Elements Backer]


### PR DESCRIPTION
FormValidationMessage was added to docs as usable, but didn't work at all.