### PR TITLE
when set image property on card container - throws layout error (fixe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,5 @@ Do you use React Native Elements in production? If so, consider supporting this 
 
 
 
-
-
 [![React Native Elements Backer](https://opencollective.com/react-native-elements/sponsor/13/avatar)](https://opencollective.com/react-native-elements/sponsor/13/website)
-[![React Native Elements Backer](https://opencollective.com/react-native-elements/sponsor/14/avatar)](https://opencollective.com/react-native-elements/sponsor/14/website)
-
-
 


### PR DESCRIPTION
It appears that if parent element don't have style flex:1, but child have (or parent don't have height hard set), the react throws error.

I'm not sure what is the idea about adding flex property here - if I remove it - visually the component looks right - it expands image to full width of the Card element.